### PR TITLE
Allow http_parser 4

### DIFF
--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>2.4.0 <3.0.0'
 
 dependencies:
-  http_parser: ">=0.0.1 <4.0.0"
+  http_parser: ">=0.0.1 <5.0.0"
   path: ^1.6.4
 
 dev_dependencies:


### PR DESCRIPTION
# Problem

dio 3 can't be used with http 0.13x since it limits http_parser to <4

# Solution

Widen the range to allow http_parser 4. There are no breaking changes in http_parser so this is safe.
https://pub.dev/packages/http_parser/changelog
