### PR TITLE
FEDX-151 Finish setting up json_annotation and json_serializable copies, support analyzer 1+2

### DIFF
--- a/json_serializable-3.5.2/README.md
+++ b/json_serializable-3.5.2/README.md
@@ -26,7 +26,7 @@ Given a library `example.dart` with an `Person` class annotated with
 `@JsonSerializable()`:
 
 ```dart
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'example.g.dart';
 
@@ -136,7 +136,7 @@ configure code generation by setting values in `build.yaml`.
 targets:
   $default:
     builders:
-      json_serializable:
+      json_serializable_3_5_2:
         options:
           # Options configure how source code is generated for every
           # `@JsonSerializable`-annotated class in the package.

--- a/json_serializable-3.5.2/build.yaml
+++ b/json_serializable-3.5.2/build.yaml
@@ -2,7 +2,7 @@
 targets:
   $default:
     builders:
-      json_serializable:
+      json_serializable_3_5_2:
         generate_for:
         - example/*
         - test/default_value/*
@@ -16,7 +16,7 @@ targets:
         generate_for:
         - test/**/**.browser_test.dart
 
-      json_serializable|_test_builder:
+      json_serializable_3_5_2|_test_builder:
         generate_for:
         - test/default_value/default_value.dart
         - test/generic_files/generic_class.dart
@@ -25,11 +25,11 @@ targets:
         - test/integration/json_test_example.non_nullable.dart
         - test/kitchen_sink/kitchen_sink.dart
 
-      json_serializable|_type_builder:
+      json_serializable_3_5_2|_type_builder:
         generate_for:
         - test/supported_types/input.dart
 
-      json_serializable|_type_test_builder:
+      json_serializable_3_5_2|_type_test_builder:
         generate_for:
         - test/supported_types/type_test.dart
 
@@ -49,7 +49,7 @@ builders:
       - .g_explicit_to_json.dart
       - .g_non_nullable.dart
     build_to: source
-    runs_before: ["json_serializable"]
+    runs_before: ["json_serializable_3_5_2"]
 
   _type_builder:
     import: 'tool/test_type_builder.dart'
@@ -72,7 +72,7 @@ builders:
       - .type_string.dart
       - .type_uri.dart
     build_to: source
-    runs_before: ["json_serializable"]
+    runs_before: ["json_serializable_3_5_2"]
 
   _type_test_builder:
     import: 'tool/test_type_builder.dart'
@@ -95,7 +95,7 @@ builders:
       - .string_test.dart
       - .uri_test.dart
     build_to: source
-    runs_before: ["json_serializable"]
+    runs_before: ["json_serializable_3_5_2"]
 
   _doc_builder:
     import: "tool/doc_builder.dart"
@@ -103,13 +103,13 @@ builders:
     build_extensions: {"lib/json_serializable.dart": ["doc/doc.md"]}
     build_to: source
     auto_apply: root_package
-    runs_before: ["json_serializable"]
+    runs_before: ["json_serializable_3_5_2"]
     required_inputs: ["doc/json_annotation_version.txt"]
 
-  json_serializable:
-    import: "package:json_serializable/builder.dart"
+  json_serializable_3_5_2:
+    import: "package:json_serializable_3_5_2/builder.dart"
     builder_factories: ["jsonSerializable"]
-    build_extensions: {".dart": ["json_serializable.g.part"]}
+    build_extensions: {".dart": ["json_serializable_3_5_2.g.part"]}
     auto_apply: dependents
     build_to: cache
     applies_builders: ["source_gen|combining_builder"]

--- a/json_serializable-3.5.2/example/example.dart
+++ b/json_serializable-3.5.2/example/example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'example.g.dart';
 

--- a/json_serializable-3.5.2/lib/builder.dart
+++ b/json_serializable-3.5.2/lib/builder.dart
@@ -27,7 +27,7 @@ Builder jsonSerializable(BuilderOptions options) {
     return jsonPartBuilder(config: config);
   } on CheckedFromJsonException catch (e) {
     final lines = <String>[
-      'Could not parse the options provided for `json_serializable`.'
+      'Could not parse the options provided for `json_serializable_3_5_2`.'
     ];
 
     if (e.key != null) {

--- a/json_serializable-3.5.2/lib/builder.dart
+++ b/json_serializable-3.5.2/lib/builder.dart
@@ -13,7 +13,7 @@
 library json_serializable.builder;
 
 import 'package:build/build.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'src/json_part_builder.dart';
 

--- a/json_serializable-3.5.2/lib/src/decode_helper.dart
+++ b/json_serializable-3.5.2/lib/src/decode_helper.dart
@@ -57,12 +57,7 @@ abstract class DecodeHelper implements HelperCore {
       element,
       accessibleFields.keys,
       accessibleFields.values
-          .where((fe) =>
-              !fe.isFinal ||
-              // Handle the case where `fe` defines a getter in `element`
-              // and there is a setter in a super class
-              // See google/json_serializable.dart#613
-              element.lookUpSetter(fe.name, element.library) != null)
+          .where((fe) => element.lookUpSetter(fe.name, element.library) != null)
           .map((fe) => fe.name)
           .toList(),
       unavailableReasons,

--- a/json_serializable-3.5.2/lib/src/decode_helper.dart
+++ b/json_serializable-3.5.2/lib/src/decode_helper.dart
@@ -70,11 +70,14 @@ abstract class DecodeHelper implements HelperCore {
     if (config.checked) {
       final classLiteral = escapeDartString(element.name);
 
-      buffer..write('''
+      buffer
+        ..write('''
   return \$checkedNew(
     $classLiteral,
     json,
-    () {\n''')..write(checks)..write('''
+    () {\n''')
+        ..write(checks)
+        ..write('''
     final val = ${data.content};''');
 
       for (final field in data.fieldsToSet) {
@@ -104,9 +107,13 @@ abstract class DecodeHelper implements HelperCore {
         fieldKeyMapArg = ', fieldKeyMap: const $mapLiteral';
       }
 
-      buffer..write(fieldKeyMapArg)..write(')');
+      buffer
+        ..write(fieldKeyMapArg)
+        ..write(')');
     } else {
-      buffer..write(checks)..write('''
+      buffer
+        ..write(checks)
+        ..write('''
   return ${data.content}''');
       for (final field in data.fieldsToSet) {
         buffer
@@ -115,7 +122,9 @@ abstract class DecodeHelper implements HelperCore {
           ..write(deserializeFun(field));
       }
     }
-    buffer..writeln(';\n}')..writeln();
+    buffer
+      ..writeln(';\n}')
+      ..writeln();
 
     return CreateFactoryResult(buffer.toString(), data.usedCtorParamsAndFields);
   }

--- a/json_serializable-3.5.2/lib/src/encoder_helper.dart
+++ b/json_serializable-3.5.2/lib/src/encoder_helper.dart
@@ -120,7 +120,9 @@ abstract class EncodeHelper implements HelperCore {
       }
     }
 
-    buffer..writeln('    return $generatedLocalVarName;')..writeln('  }');
+    buffer
+      ..writeln('    return $generatedLocalVarName;')
+      ..writeln('  }');
   }
 
   String _serializeField(FieldElement field, String accessExpression) {

--- a/json_serializable-3.5.2/lib/src/encoder_helper.dart
+++ b/json_serializable-3.5.2/lib/src/encoder_helper.dart
@@ -4,7 +4,7 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'constants.dart';
 import 'helper_core.dart';

--- a/json_serializable-3.5.2/lib/src/field_helpers.dart
+++ b/json_serializable-3.5.2/lib/src/field_helpers.dart
@@ -58,9 +58,8 @@ class _FieldSet implements Comparable<_FieldSet> {
     /// Returns the offset of given field/property in its source file – with a
     /// preference for the getter if it's defined.
     int _offsetFor(FieldElement e) {
-      if (e.getter != null && e.getter.nameOffset != e.nameOffset) {
-        assert(e.nameOffset == -1);
-        return e.getter.nameOffset;
+      if (e.isSynthetic) {
+        return (e.getter ?? e.setter).nameOffset;
       }
       return e.nameOffset;
     }

--- a/json_serializable-3.5.2/lib/src/field_helpers.dart
+++ b/json_serializable-3.5.2/lib/src/field_helpers.dart
@@ -102,7 +102,7 @@ Iterable<FieldElement> createSortedFieldSet(ClassElement element) {
   final fields = allFields
       .map((e) => _FieldSet(elementInstanceFields[e], inheritedFields[e]))
       .toList()
-        ..sort();
+    ..sort();
 
   return fields.map((fs) => fs.field).toList();
 }

--- a/json_serializable-3.5.2/lib/src/helper_core.dart
+++ b/json_serializable-3.5.2/lib/src/helper_core.dart
@@ -4,7 +4,7 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:source_gen/source_gen.dart';
 

--- a/json_serializable-3.5.2/lib/src/json_key_utils.dart
+++ b/json_serializable-3.5.2/lib/src/json_key_utils.dart
@@ -152,7 +152,7 @@ JsonKey _from(FieldElement element, JsonSerializable classAnnotation) {
         }
         assert(targetEnumType != null);
         final annotatedEnumType = annotationValue.objectValue.type;
-        if (annotatedEnumType != targetEnumType) {
+        if (!_interfaceTypesEqual(annotatedEnumType, targetEnumType)) {
           throwUnsupported(
             element,
             '`$fieldName` has type '
@@ -276,4 +276,12 @@ bool _includeIfNull(
     return false;
   }
   return keyIncludeIfNull ?? classIncludeIfNull;
+}
+
+bool _interfaceTypesEqual(DartType a, DartType b) {
+  if (a is InterfaceType && b is InterfaceType) {
+    // Handle nullability case. Pretty sure this is fine for enums.
+    return a.element == b.element;
+  }
+  return a == b;
 }

--- a/json_serializable-3.5.2/lib/src/json_key_utils.dart
+++ b/json_serializable-3.5.2/lib/src/json_key_utils.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'json_literal_generator.dart';
@@ -120,7 +120,7 @@ JsonKey _from(FieldElement element, JsonSerializable classAnnotation) {
     throwUnsupported(
       element,
       'The provided value is not supported: $badType. '
-      'This may be an error in package:json_serializable. '
+      'This may be an error in package:json_serializable_3_5_2. '
       'Please rerun your build with `--verbose` and file an issue.',
     );
   }

--- a/json_serializable-3.5.2/lib/src/json_literal_generator.dart
+++ b/json_serializable-3.5.2/lib/src/json_literal_generator.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_gen/source_gen.dart';
 

--- a/json_serializable-3.5.2/lib/src/json_part_builder.dart
+++ b/json_serializable-3.5.2/lib/src/json_part_builder.dart
@@ -26,7 +26,7 @@ Builder jsonPartBuilder({
       JsonSerializableGenerator.fromSettings(settings),
       const JsonLiteralGenerator(),
     ],
-    'json_serializable',
+    'json_serializable_3_5_2',
     formatOutput: formatOutput,
   );
 }

--- a/json_serializable-3.5.2/lib/src/json_part_builder.dart
+++ b/json_serializable-3.5.2/lib/src/json_part_builder.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'json_literal_generator.dart';

--- a/json_serializable-3.5.2/lib/src/json_serializable_generator.dart
+++ b/json_serializable-3.5.2/lib/src/json_serializable_generator.dart
@@ -4,7 +4,7 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'generator_helper.dart';

--- a/json_serializable-3.5.2/lib/src/settings.dart
+++ b/json_serializable-3.5.2/lib/src/settings.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'type_helper.dart';
 import 'type_helpers/big_int_helper.dart';

--- a/json_serializable-3.5.2/lib/src/type_helper.dart
+++ b/json_serializable-3.5.2/lib/src/type_helper.dart
@@ -4,7 +4,7 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 /// Context information provided in calls to [TypeHelper.serialize] and
 /// [TypeHelper.deserialize].

--- a/json_serializable-3.5.2/lib/src/type_helper_ctx.dart
+++ b/json_serializable-3.5.2/lib/src/type_helper_ctx.dart
@@ -5,7 +5,7 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'helper_core.dart';
 import 'type_helper.dart';

--- a/json_serializable-3.5.2/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable-3.5.2/lib/src/type_helpers/json_converter_helper.dart
@@ -5,7 +5,7 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
 import '../helper_core.dart';

--- a/json_serializable-3.5.2/lib/src/type_helpers/json_helper.dart
+++ b/json_serializable-3.5.2/lib/src/type_helpers/json_helper.dart
@@ -5,7 +5,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
 import '../shared_checkers.dart';

--- a/json_serializable-3.5.2/lib/src/utils.dart
+++ b/json_serializable-3.5.2/lib/src/utils.dart
@@ -5,7 +5,7 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'package:meta/meta.dart' show alwaysThrows, required;
 import 'package:source_gen/source_gen.dart';
 

--- a/json_serializable-3.5.2/pubspec.yaml
+++ b/json_serializable-3.5.2/pubspec.yaml
@@ -17,10 +17,10 @@ dependencies:
   # For v3 only – allow a wide range since the only change was to REMOVE things
   # from json_annotation
   json_annotation_3_1_1:
-    hosted:
-      name: json_annotation_3_1_1
-      url: https://pub.workiva.org
-    version: ^5.3.0 # This version doesn't matter, there's only the 3_1_1 forked version
+    git:
+      url: https://github.com/Workiva/w_dio.git
+      ref: analyzer_2
+      path: json_annotation-3.1.1
   meta: ^1.1.0
   path: ^1.3.2
   source_gen: '>=0.9.6 <2.0.0'
@@ -38,7 +38,4 @@ dev_dependencies:
 
 dependency_overrides:
   json_annotation_3_1_1:
-    git:
-      url: https://github.com/Workiva/w_dio.git
-      ref: analyzer_2
-      path: json_annotation-3.1.1
+    path: ../json_annotation-3.1.1

--- a/json_serializable-3.5.2/pubspec.yaml
+++ b/json_serializable-3.5.2/pubspec.yaml
@@ -17,10 +17,10 @@ dependencies:
   # For v3 only – allow a wide range since the only change was to REMOVE things
   # from json_annotation
   json_annotation_3_1_1:
-    git:
-      url: https://github.com/Workiva/w_dio.git
-      ref: analyzer_2
-      path: json_annotation-3.1.1
+    hosted:
+      name: json_annotation_3_1_1
+      url: https://pub.workiva.org
+    version: ^5.3.0 # This version doesn't matter, there's only the 3_1_1 forked version
   meta: ^1.1.0
   path: ^1.3.2
   source_gen: '>=0.9.6 <2.0.0'
@@ -35,7 +35,3 @@ dev_dependencies:
   source_gen_test: '>=0.1.0 <2.0.0'
   test: ^1.6.0
   yaml: ^3.0.0
-
-dependency_overrides:
-  json_annotation_3_1_1:
-    path: ../json_annotation-3.1.1

--- a/json_serializable-3.5.2/pubspec.yaml
+++ b/json_serializable-3.5.2/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.11.99 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.39.0 <2.0.0'
+  analyzer: '>=1.7.0 <3.0.0'
   build: '>=0.12.6 <3.0.0'
   build_config: '>=0.2.6 <2.0.0'
 
@@ -23,15 +23,22 @@ dependencies:
     version: ^5.3.0 # This version doesn't matter, there's only the 3_1_1 forked version
   meta: ^1.1.0
   path: ^1.3.2
-  source_gen: ^0.9.6
+  source_gen: '>=0.9.6 <2.0.0'
 
 dev_dependencies:
-  build_runner: ^1.0.0
+  build_runner: ^2.0.0
   build_verify: ^2.0.0
   collection: ^1.14.0
-  dart_style: ^1.0.0
+  dart_style: '>=1.0.0 <3.0.0'
   logging: ^1.0.0
   pub_semver: ^2.0.0
-  source_gen_test: ^0.1.0
+  source_gen_test: '>=0.1.0 <2.0.0'
   test: ^1.6.0
   yaml: ^3.0.0
+
+dependency_overrides:
+  json_annotation_3_1_1:
+    git:
+      url: https://github.com/Workiva/w_dio.git
+      ref: analyzer_2
+      path: json_annotation-3.1.1

--- a/json_serializable-3.5.2/test/config_test.dart
+++ b/json_serializable-3.5.2/test/config_test.dart
@@ -68,7 +68,7 @@ void main() {
       'targets',
       r'$default',
       'builders',
-      'json_serializable',
+      'json_serializable_3_5_2',
       'options'
     ]) {
       yaml = yaml[key] as YamlMap;
@@ -92,7 +92,7 @@ void main() {
     final matcher = isA<StateError>().having(
       (v) => v.message,
       'message',
-      'Could not parse the options provided for `json_serializable`.\n'
+      'Could not parse the options provided for `json_serializable_3_5_2`.\n'
           'Unrecognized keys: [unsupported]; '
           'supported keys: [${_invalidConfig.keys.join(', ')}]',
     );
@@ -120,7 +120,7 @@ void main() {
           (v) => v.message,
           'message',
           '''
-Could not parse the options provided for `json_serializable`.
+Could not parse the options provided for `json_serializable_3_5_2`.
 There is a problem with "${entry.key}".
 $lastLine''',
         );

--- a/json_serializable-3.5.2/test/config_test.dart
+++ b/json_serializable-3.5.2/test/config_test.dart
@@ -6,9 +6,9 @@
 import 'dart:io';
 
 import 'package:build/build.dart';
-import 'package:json_annotation/json_annotation.dart';
-import 'package:json_serializable/builder.dart';
-import 'package:json_serializable/src/json_serializable_generator.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
+import 'package:json_serializable_3_5_2/builder.dart';
+import 'package:json_serializable_3_5_2/src/json_serializable_generator.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 

--- a/json_serializable-3.5.2/test/custom_configuration_test.dart
+++ b/json_serializable-3.5.2/test/custom_configuration_test.dart
@@ -6,10 +6,10 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/element/type.dart';
-import 'package:json_annotation/json_annotation.dart';
-import 'package:json_serializable/json_serializable.dart';
-import 'package:json_serializable/src/constants.dart';
-import 'package:json_serializable/src/type_helper.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
+import 'package:json_serializable_3_5_2/json_serializable.dart';
+import 'package:json_serializable_3_5_2/src/constants.dart';
+import 'package:json_serializable_3_5_2/src/type_helper.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_gen/source_gen.dart';
 import 'package:source_gen_test/source_gen_test.dart';

--- a/json_serializable-3.5.2/test/default_value/default_value.dart
+++ b/json_serializable-3.5.2/test/default_value/default_value.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: annotate_overrides
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'default_value_interface.dart' as dvi hide Greek;
 import 'default_value_interface.dart' show Greek;

--- a/json_serializable-3.5.2/test/default_value/default_value.g_any_map__checked.dart
+++ b/json_serializable-3.5.2/test/default_value/default_value.g_any_map__checked.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: annotate_overrides
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'default_value_interface.dart' as dvi hide Greek;
 import 'default_value_interface.dart' show Greek;

--- a/json_serializable-3.5.2/test/ensure_build_test.dart
+++ b/json_serializable-3.5.2/test/ensure_build_test.dart
@@ -8,6 +8,8 @@ import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('ensure_build',
-      () => expectBuildClean(packageRelativeDirectory: 'json_serializable_3_5_2'));
+  test(
+      'ensure_build',
+      () => expectBuildClean(
+          packageRelativeDirectory: 'json_serializable_3_5_2'));
 }

--- a/json_serializable-3.5.2/test/ensure_build_test.dart
+++ b/json_serializable-3.5.2/test/ensure_build_test.dart
@@ -9,5 +9,5 @@ import 'package:test/test.dart';
 
 void main() {
   test('ensure_build',
-      () => expectBuildClean(packageRelativeDirectory: 'json_serializable'));
+      () => expectBuildClean(packageRelativeDirectory: 'json_serializable_3_5_2'));
 }

--- a/json_serializable-3.5.2/test/enum_helper_test.dart
+++ b/json_serializable-3.5.2/test/enum_helper_test.dart
@@ -5,7 +5,7 @@
 @TestOn('vm')
 
 import 'package:test/test.dart';
-import 'package:json_serializable/src/type_helpers/enum_helper.dart';
+import 'package:json_serializable_3_5_2/src/type_helpers/enum_helper.dart';
 
 void main() {
   group('expression test', () {

--- a/json_serializable-3.5.2/test/generic_files/generic_argument_factories.dart
+++ b/json_serializable-3.5.2/test/generic_files/generic_argument_factories.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'generic_argument_factories.g.dart';
 

--- a/json_serializable-3.5.2/test/generic_files/generic_class.dart
+++ b/json_serializable-3.5.2/test/generic_files/generic_class.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'generic_class.g.dart';
 

--- a/json_serializable-3.5.2/test/integration/json_test_common.dart
+++ b/json_serializable-3.5.2/test/integration/json_test_common.dart
@@ -5,7 +5,7 @@
 import 'dart:collection';
 
 import 'package:collection/collection.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 enum Category {
   top,

--- a/json_serializable-3.5.2/test/integration/json_test_example.dart
+++ b/json_serializable-3.5.2/test/integration/json_test_example.dart
@@ -5,7 +5,7 @@
 // ignore_for_file: hash_and_equals
 import 'dart:collection';
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_test_common.dart';
 

--- a/json_serializable-3.5.2/test/integration/json_test_example.g_any_map.dart
+++ b/json_serializable-3.5.2/test/integration/json_test_example.g_any_map.dart
@@ -5,7 +5,7 @@
 // ignore_for_file: hash_and_equals
 import 'dart:collection';
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_test_common.dart';
 

--- a/json_serializable-3.5.2/test/integration/json_test_example.g_non_nullable.dart
+++ b/json_serializable-3.5.2/test/integration/json_test_example.g_non_nullable.dart
@@ -5,7 +5,7 @@
 // ignore_for_file: hash_and_equals
 import 'dart:collection';
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_test_common.dart';
 

--- a/json_serializable-3.5.2/test/integration/json_test_example.g_non_nullable.g.dart
+++ b/json_serializable-3.5.2/test/integration/json_test_example.g_non_nullable.g.dart
@@ -191,7 +191,8 @@ UnknownEnumValue _$UnknownEnumValueFromJson(Map<String, dynamic> json) {
     ..enumValue = _$enumDecode(_$CategoryEnumMap, json['enumValue'],
         unknownValue: Category.notDiscoveredYet)
     ..enumIterable = (json['enumIterable'] as List).map((e) => _$enumDecode(
-        _$CategoryEnumMap, e, unknownValue: Category.notDiscoveredYet))
+        _$CategoryEnumMap, e,
+        unknownValue: Category.notDiscoveredYet))
     ..enumList = (json['enumList'] as List)
         .map((e) => _$enumDecode(_$CategoryEnumMap, e,
             unknownValue: Category.notDiscoveredYet))

--- a/json_serializable-3.5.2/test/json_serializable_test.dart
+++ b/json_serializable-3.5.2/test/json_serializable_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
-import 'package:json_serializable/json_serializable.dart';
+import 'package:json_serializable_3_5_2/json_serializable.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_gen_test/source_gen_test.dart';
 import 'package:test/test.dart';

--- a/json_serializable-3.5.2/test/kitchen_sink/json_converters.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/json_converters.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 class GenericConverter<T> implements JsonConverter<T, Map<String, dynamic>> {
   const GenericConverter();

--- a/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: annotate_overrides, hash_and_equals
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;

--- a/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_any_map.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_any_map.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: annotate_overrides, hash_and_equals
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;

--- a/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_any_map__checked__non_nullable.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_any_map__checked__non_nullable.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: annotate_overrides, hash_and_equals
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;

--- a/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_any_map__non_nullable.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_any_map__non_nullable.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: annotate_overrides, hash_and_equals
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;

--- a/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_exclude_null.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_exclude_null.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: annotate_overrides, hash_and_equals
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;

--- a/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_exclude_null__non_nullable.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_exclude_null__non_nullable.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: annotate_overrides, hash_and_equals
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;

--- a/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_explicit_to_json.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_explicit_to_json.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: annotate_overrides, hash_and_equals
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;

--- a/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_non_nullable.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink.g_non_nullable.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: annotate_overrides, hash_and_equals
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;

--- a/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink_test.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/kitchen_sink_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 

--- a/json_serializable-3.5.2/test/kitchen_sink/simple_object.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/simple_object.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'simple_object.g.dart';
 

--- a/json_serializable-3.5.2/test/kitchen_sink/strict_keys_object.dart
+++ b/json_serializable-3.5.2/test/kitchen_sink/strict_keys_object.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'strict_keys_object.g.dart';
 

--- a/json_serializable-3.5.2/test/literal/json_literal.dart
+++ b/json_serializable-3.5.2/test/literal/json_literal.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 part 'json_literal.g.dart';
 
 @JsonLiteral('json_literal.json')

--- a/json_serializable-3.5.2/test/shared_config.dart
+++ b/json_serializable-3.5.2/test/shared_config.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 final jsonSerializableFields = generatorConfigDefaultJson.keys.toList();
 

--- a/json_serializable-3.5.2/test/src/_json_serializable_test_input.dart
+++ b/json_serializable-3.5.2/test/src/_json_serializable_test_input.dart
@@ -4,8 +4,8 @@
 
 import 'dart:collection';
 
-import 'package:json_annotation/json_annotation.dart';
-import 'package:json_serializable/src/helper_core.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
+import 'package:json_serializable_3_5_2/src/helper_core.dart';
 import 'package:source_gen_test/annotations.dart';
 
 part 'checked_test_input.dart';

--- a/json_serializable-3.5.2/test/supported_types/input.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.g.dart';
 

--- a/json_serializable-3.5.2/test/supported_types/input.type_bigint.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_bigint.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.type_bigint.g.dart';
 

--- a/json_serializable-3.5.2/test/supported_types/input.type_bool.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_bool.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.type_bool.g.dart';
 

--- a/json_serializable-3.5.2/test/supported_types/input.type_datetime.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_datetime.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.type_datetime.g.dart';
 

--- a/json_serializable-3.5.2/test/supported_types/input.type_double.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_double.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.type_double.g.dart';
 

--- a/json_serializable-3.5.2/test/supported_types/input.type_duration.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_duration.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.type_duration.g.dart';
 

--- a/json_serializable-3.5.2/test/supported_types/input.type_enumtype.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_enumtype.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'enum_type.dart';
 
 part 'input.type_enumtype.g.dart';

--- a/json_serializable-3.5.2/test/supported_types/input.type_int.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_int.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.type_int.g.dart';
 

--- a/json_serializable-3.5.2/test/supported_types/input.type_iterable.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_iterable.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'enum_type.dart';
 
 part 'input.type_iterable.g.dart';

--- a/json_serializable-3.5.2/test/supported_types/input.type_list.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_list.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'enum_type.dart';
 
 part 'input.type_list.g.dart';

--- a/json_serializable-3.5.2/test/supported_types/input.type_map.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_map.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'enum_type.dart';
 
 part 'input.type_map.g.dart';

--- a/json_serializable-3.5.2/test/supported_types/input.type_num.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_num.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.type_num.g.dart';
 

--- a/json_serializable-3.5.2/test/supported_types/input.type_object.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_object.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.type_object.g.dart';
 

--- a/json_serializable-3.5.2/test/supported_types/input.type_set.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_set.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 import 'enum_type.dart';
 
 part 'input.type_set.g.dart';

--- a/json_serializable-3.5.2/test/supported_types/input.type_string.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_string.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.type_string.g.dart';
 

--- a/json_serializable-3.5.2/test/supported_types/input.type_uri.dart
+++ b/json_serializable-3.5.2/test/supported_types/input.type_uri.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 part 'input.type_uri.g.dart';
 

--- a/json_serializable-3.5.2/test/test_sources/test_sources.dart
+++ b/json_serializable-3.5.2/test/test_sources/test_sources.dart
@@ -1,4 +1,4 @@
-import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation_3_1_1/json_annotation.dart';
 
 @JsonSerializable()
 class ConfigurationImplicitDefaults {

--- a/json_serializable-3.5.2/test/utils_test.dart
+++ b/json_serializable-3.5.2/test/utils_test.dart
@@ -6,7 +6,7 @@
 
 import 'package:test/test.dart';
 
-import 'package:json_serializable/src/utils.dart';
+import 'package:json_serializable_3_5_2/src/utils.dart';
 
 const _kebabItems = {
   'simple': 'simple',

--- a/json_serializable-3.5.2/tool/doc_builder.dart
+++ b/json_serializable-3.5.2/tool/doc_builder.dart
@@ -34,7 +34,7 @@ class _DocBuilder extends Builder {
         : jsonAnnotationVersion.toString();
 
     final lib = LibraryReader(await buildStep.resolver.libraryFor(
-        AssetId.resolve('package:json_annotation_3_1_1/json_annotation.dart')));
+        resolveAssetId('package:json_annotation_3_1_1/json_annotation.dart')));
 
     final descriptionMap = <String, _FieldInfo>{};
 
@@ -188,4 +188,26 @@ class _FieldInfo implements Comparable<_FieldInfo> {
 
   @override
   String toString() => '_FieldThing($_keyField)';
+}
+
+// Copied from https://github.com/Workiva/over_react/blob/ab689643a0c06b921ce84872bd7cee37a08cf11f/lib/src/builder/builder.dart#L226C1-L245C2
+/// A compatibility layer for [AssetId.resolve],
+/// which in build <2.0.0 accepts a String for the first argument and
+/// and in build >=2.0.0 accepts a Uri for the first argument.
+///
+/// This function allows us to support build 1.x and 2.x
+///
+// TODO remove once we're off of build 1.x
+AssetId resolveAssetId(String uri, {AssetId from}) {
+  try {
+    // `as dynamic` is necessary to prevent compile errors.
+    // This ignore is to prevent analysis implicit cast errors.
+    // ignore: argument_type_not_assignable
+    return AssetId.resolve(uri as dynamic, from: from);
+  } catch (_) {
+    // `as dynamic` is necessary to prevent compile errors.
+    // This ignore is to prevent analysis implicit cast errors.
+    // ignore: argument_type_not_assignable
+    return AssetId.resolve(Uri.parse(uri) as dynamic, from: from);
+  }
 }

--- a/json_serializable-3.5.2/tool/doc_builder.dart
+++ b/json_serializable-3.5.2/tool/doc_builder.dart
@@ -23,7 +23,7 @@ class _DocBuilder extends Builder {
     final lockFileYaml =
         loadYaml(lockFileContent, sourceUrl: lockFileAssetId.uri);
     final pkgMap = lockFileYaml['packages'] as YamlMap;
-    final jsonAnnotationMap = pkgMap['json_annotation'] as YamlMap;
+    final jsonAnnotationMap = pkgMap['json_annotation_3_1_1'] as YamlMap;
     final jsonAnnotationVersionString = jsonAnnotationMap['version'] as String;
 
     final jsonAnnotationVersion =

--- a/json_serializable-3.5.2/tool/doc_builder.dart
+++ b/json_serializable-3.5.2/tool/doc_builder.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
-import 'package:json_serializable/src/utils.dart';
+import 'package:json_serializable_3_5_2/src/utils.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:yaml/yaml.dart';
@@ -34,7 +34,7 @@ class _DocBuilder extends Builder {
         : jsonAnnotationVersion.toString();
 
     final lib = LibraryReader(await buildStep.resolver.libraryFor(
-        AssetId.resolve('package:json_annotation/json_annotation.dart')));
+        AssetId.resolve('package:json_annotation_3_1_1/json_annotation.dart')));
 
     final descriptionMap = <String, _FieldInfo>{};
 

--- a/json_serializable-3.5.2/tool/set_analyzer_constraint.dart
+++ b/json_serializable-3.5.2/tool/set_analyzer_constraint.dart
@@ -1,0 +1,26 @@
+// Copied from https://github.com/Workiva/over_react/blob/ab689643a0c06b921ce84872bd7cee37a08cf11f/tool/set_analyzer_constraint.dart
+import 'dart:io';
+
+final analyzerConstraintPattern =
+    RegExp(r'^( +analyzer:\s*).+', multiLine: true);
+
+void main(List<String> args) {
+  if (args.length != 1) {
+    throw ArgumentError(
+        'Expected a single arg for the new analyzer constraint. Args: $args');
+  }
+  final newAnalyzerConstraint = args.single;
+
+  final pubspec = File('pubspec.yaml');
+  final pubspecContents = pubspec.readAsStringSync();
+
+  final matches = analyzerConstraintPattern.allMatches(pubspecContents);
+  if (matches.length != 1) {
+    throw Exception(
+        'Expected 1 analyzer dependency match in ${pubspec.path}, but found ${matches.length}.');
+  }
+
+  pubspec.writeAsStringSync(pubspecContents.replaceFirstMapped(
+      analyzerConstraintPattern,
+      (match) => '${match.group(1)}$newAnalyzerConstraint'));
+}

--- a/json_serializable-3.5.2/tool/test_builder.dart
+++ b/json_serializable-3.5.2/tool/test_builder.dart
@@ -183,7 +183,7 @@ List<String> get _fileConfigurations => _fileConfigurationMap.values
     .followedBy(['.factories.dart'])
     .toSet()
     .toList()
-      ..sort();
+  ..sort();
 
 const _kitchenSinkBaseName = 'kitchen_sink';
 

--- a/json_serializable-3.5.2/tool/test_type_data.dart
+++ b/json_serializable-3.5.2/tool/test_type_data.dart
@@ -5,7 +5,7 @@ import 'shared.dart';
 const customEnumType = 'EnumType';
 
 const _annotationImport =
-    "import 'package:json_annotation/json_annotation.dart';";
+    "import 'package:json_annotation_3_1_1/json_annotation.dart';";
 
 class TestTypeData {
   final String defaultExpression;

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -64,7 +64,7 @@ scripts:
   - merge_branch.sh master
   - cd json_serializable-3.5.2
   - |
-    echo "\ndependency_overrides:\n  json_annotation_3_1_1:\n    path: ../json_annotation_3_1_1" >> pubspec.yaml
+    echo -e '\ndependency_overrides:\n  json_annotation_3_1_1:\n    path: ../json_annotation_3_1_1' >> pubspec.yaml
   - git diff pubspec.yaml
   - timeout 2m dart pub get
   - cp pubspec.lock /testing/artifacts/

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -64,7 +64,7 @@ scripts:
   - merge_branch.sh master
   - cd json_serializable-3.5.2
   - |
-    echo -e '\ndependency_overrides:\n  json_annotation_3_1_1:\n    path: ../json_annotation_3_1_1' >> pubspec.yaml
+    echo -e '\ndependency_overrides:\n  json_annotation_3_1_1:\n    path: ../json_annotation-3.1.1' >> pubspec.yaml
   - git diff pubspec.yaml
   - timeout 2m dart pub get
   - cp pubspec.lock /testing/artifacts/

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,4 +1,4 @@
-name: quality_checks
+name: dio_quality_checks
 description: Runs Dart analysis and unit tests
 contact: 'Frontend Architecture / #support-frontend-architecture'
 
@@ -18,4 +18,128 @@ scripts:
   - chmod +x ./scripts/prepare_pinning_certs.sh
   - ./scripts/prepare_pinning_certs.sh
   - cd dio
+  - dart test -p vm
+
+---
+
+name: json_annotation_quality_checks
+description: Runs Dart analysis and unit tests
+contact: 'Frontend Architecture / #support-frontend-architecture'
+
+image: drydock-prod.workiva.net/workiva/dart2_base_image:1
+size: medium
+timeout: 300 # 5 minutes
+
+artifacts:
+  - /testing/artifacts
+
+scripts:
+  - merge_branch.sh master
+  - cd json_annotation-3.1.1
+  - timeout 2m dart pub get
+  - cp pubspec.lock /testing/artifacts/
+  - dart analyze
+  - dart format --set-exit-if-changed .
+  - |
+    if [ -d ./test/ ]; then
+      dart test -p vm
+    else
+      echo No tests to run.
+    fi
+
+---
+
+name: json_serializable_and_json_annotation_integration
+description: Runs Dart analysis and unit tests when pulling json_annotation into json_serializable
+contact: 'Frontend Architecture / #support-frontend-architecture'
+
+image: drydock-prod.workiva.net/workiva/dart2_base_image:1
+size: medium
+timeout: 300 # 5 minutes
+
+artifacts:
+  - /testing/artifacts
+
+scripts:
+  - merge_branch.sh master
+  - cd json_serializable-3.5.2
+  - |
+    echo "\ndependency_overrides:\n  json_annotation_3_1_1:\n    path: ../json_annotation_3_1_1" >> pubspec.yaml
+  - git diff pubspec.yaml
+  - timeout 2m dart pub get
+  - cp pubspec.lock /testing/artifacts/
+  - dart analyze
+  - dart format --set-exit-if-changed .
+  - dart test -p vm
+
+---
+
+name: json_serializable_quality_checks
+description: Runs Dart analysis and unit tests
+contact: 'Frontend Architecture / #support-frontend-architecture'
+
+image: drydock-prod.workiva.net/workiva/dart2_base_image:1
+size: medium
+timeout: 300 # 5 minutes
+
+artifacts:
+  - /testing/artifacts
+
+scripts:
+  - merge_branch.sh master
+  - cd json_serializable-3.5.2
+  - timeout 2m dart pub get
+  - cp pubspec.lock /testing/artifacts/
+  - dart analyze
+  - dart format --set-exit-if-changed .
+  - dart test -p vm
+
+---
+
+name: json_serializable_quality_checks_analyzer_1
+description: Runs Dart analysis and unit tests when resolved to analyzer 1.x
+contact: 'Frontend Architecture / #support-frontend-architecture'
+
+image: drydock-prod.workiva.net/workiva/dart2_base_image:1
+size: medium
+timeout: 300 # 5 minutes
+
+artifacts:
+  - /testing/artifacts
+
+scripts:
+  - merge_branch.sh master
+  - cd json_serializable-3.5.2
+  - dart tool/set_analyzer_constraint.dart '^1.7.0'
+  # Show the updated version constraint
+  - git diff pubspec.yaml
+  - timeout 2m dart pub get
+  - cp pubspec.lock /testing/artifacts/
+  - dart analyze
+  - dart format --set-exit-if-changed .
+  - dart test -p vm
+
+---
+
+name: json_serializable_quality_checks_analyzer_2
+description: Runs Dart analysis and unit tests when resolved to analyzer 2.x
+contact: 'Frontend Architecture / #support-frontend-architecture'
+
+image: drydock-prod.workiva.net/workiva/dart2_base_image:1
+size: medium
+timeout: 300 # 5 minutes
+
+artifacts:
+  - /testing/artifacts
+
+scripts:
+  - merge_branch.sh master
+  - cd json_serializable-3.5.2
+  - dart tool/set_analyzer_constraint.dart '^2.0.0'
+  # Show the updated version constraint
+  - git diff pubspec.yaml
+  - timeout 2m dart pub get
+  - cp pubspec.lock /testing/artifacts/
+  - dart analyze
+  - dart format --set-exit-if-changed .
   - dart test -p vm


### PR DESCRIPTION
## Motivation
All versions of json_serializable that support analyzer 2.x generate null-safe code, which makes it more complicated to upgrade to analyzer 2.x in packages that aren't yet migrated to null safety.

Ideally, we'd like a version of json_serializable that resolves to analyzer 2.x but doesn't emit null-safe code.

This repo already has a copy of the last json_serializable version (3.5.2) that generated non-null-safe code, as well a copy of the associated json_annotation. However, these copies weren't fully set up, and needed to be upgraded to newer analyzer versions.

## Changes
- Finish setting up these json_ packages
    - Set up CI checks
    - Update references to the original packages to their copied versions. This includes package imports, and keys used in builders and their configurations
        - Update `json_serializable` references to `json_serializable_3_5_2`
        - Update `json_annotation` references to `json_annotation_3_1_1`
- Update json_serializable to support analyzer 1.x and 2.x. This included:
    - Updating dependencies
    - Backpatching some changes from newer json_serializable versions (see commit messages for original changes)
        - 9e0d05d56798fa7f045f53a6125c996de092999a
        - e2235d63a76509d3633ed347f281dc0a5725fd26

## QA instructions
- CI passes
- Validate CI setup:
    - json_serializable_quality_checks_analyzer_1 resolves to analyzer 1.x
    - json_serializable_quality_checks_analyzer_2 resolves to analyzer 2.x
    - json_serializable_and_json_annotation_integration resolves to overridden json_annotation path
- Verify there are no Pub publish errors (warnings are okay) when running `dart pub publish --dry-run` within the json_serializable-3.5.2 directory