### PR TITLE
Update dev dependencies for analyzer 2

### DIFF
--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
   coverage: ^1.0.3
   crypto: ^3.0.2
   mockito: ^5.2.0
-  build_runner: any
+  build_runner: ^2.0.0

--- a/json_serializable-3.5.2/pubspec.yaml
+++ b/json_serializable-3.5.2/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.11.99 <3.0.0'
 
 dependencies:
-  analyzer: '>=1.7.0 <3.0.0'
+  analyzer: ^2.0.0
   build: '>=0.12.6 <3.0.0'
   build_config: '>=0.2.6 <2.0.0'
 
@@ -29,7 +29,7 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_verify: ^2.0.0
   collection: ^1.14.0
-  dart_style: '>=1.0.0 <3.0.0'
+  dart_style: ^2.0.0
   logging: ^1.0.0
   pub_semver: ^2.0.0
   source_gen_test: '>=0.1.0 <2.0.0'


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! Now that we can resolve to analyzer 2
we can raise the minimums of many dependencies were ranged to support both 
analyzer 1 and 2.

```
  pubspec_codemod raise-min analyzer 2.0.0 --recursive
  pubspec_codemod raise-min dependency_validator 3.0.0 --recursive
  pubspec_codemod raise-min test_html_builder 3.0.0 --recursive
  pubspec_codemod raise-min dart_style 2.0.0 --recursive
  pubspec_codemod raise-min build_web_compilers 3.0.0 --recursive
  pubspec_codemod raise-min build_test 2.0.0 --recursive
  pubspec_codemod raise-min build_runner 2.0.0 --recursive
  pubspec_codemod raise-min w_common 3.0.0 --recursive
  pubspec_codemod raise-min w_common_tools 3.0.0 --recursive
  pubspec_codemod raise-min uuid 3.0.0 --recursive
  pubspec_codemod raise-min fluri 2.0.0 --recursive
  pubspec_codemod raise-min get_it 6.0.0 --recursive
  pubspec_codemod raise-min dart_dev 4.0.0 --recursive
```

A passing CI is sufficient QA (that means dependencies resolve and tests run and pass).

For question or concerns visit `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/update_dev_deps_analyzer2`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/update_dev_deps_analyzer2)