### PR TITLE
Avoid meta 1.10.0

### DIFF
--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   async: ^2.8.2
   http_parser: ^4.0.0
-  meta: ^1.5.0
+  meta: '>=1.5.0  <1.10.0'
   path: ^1.8.0
 
 dev_dependencies:
@@ -26,3 +26,6 @@ dev_dependencies:
   crypto: ^3.0.2
   mockito: ^5.2.0
   build_runner: any
+dependency_validator:
+  ignore:
+    - meta

--- a/json_serializable-3.5.2/pubspec.yaml
+++ b/json_serializable-3.5.2/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
       name: json_annotation_3_1_1
       url: https://pub.workiva.org
     version: ^5.3.0 # This version doesn't matter, there's only the 3_1_1 forked version
-  meta: ^1.1.0
+  meta: '>=1.1.0  <1.10.0'
   path: ^1.3.2
   source_gen: '>=0.9.6 <2.0.0'
 
@@ -35,3 +35,6 @@ dev_dependencies:
   source_gen_test: '>=0.1.0 <2.0.0'
   test: ^1.6.0
   yaml: ^3.0.0
+dependency_validator:
+  ignore:
+    - meta


### PR DESCRIPTION
Summary
---
This is a batch change to apply a dependency range pin to the meta package
in order to avoid a "bad release". That version causes nearly all of our builds to
fail (anything on analyzer < 5).
So restricting the version range to <1.10.0 works around the issue until we
can upgrade to analyzer 5.

For more info, visit `#lang-dart` in Slack.

[_Created by Sourcegraph batch change `Workiva/avoid_meta_1_10_0`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/avoid_meta_1_10_0)